### PR TITLE
Fixed incorrect call to Mojo::DOM->attrs

### DIFF
--- a/lib/Google/Voice.pm
+++ b/lib/Google/Voice.pm
@@ -36,7 +36,7 @@ sub login {
       $c->get('https://accounts.google.com/ServiceLogin')
       ->res->dom->at('input[name="GALX"]');
 
-    my $galx = $el->attrs->{value} if $el;
+    my $galx = $el->attr->{value} if $el;
 
     $c->post(
         'https://accounts.google.com/ServiceLogin',
@@ -54,7 +54,7 @@ sub login {
     # Login not accepted
     return unless $el;
 
-    $self->rnr_se($el->attrs->{value});
+    $self->rnr_se($el->attr->{value});
 
     return $self;
 }


### PR DESCRIPTION
Looks like Mojo::DOM might have changed, there is no attrs method anymore, it's attr. Just changing these two lines and it works just fine again. 